### PR TITLE
Add description to PDSMS desktop menu entry on Linux

### DIFF
--- a/pdsms-linux.sh
+++ b/pdsms-linux.sh
@@ -36,7 +36,8 @@ Type=Application
 Name=Pokemon DS Map Studio
 Exec=/usr/bin/java -jar \"${PWD}/Pokemon DS Map Studio-2.2/lib/Pokemon DS Map Studio-2.2.jar\"
 Icon=${PWD}/Pokemon DS Map Studio-2.2/icon.png
-Categories=Development;
+Categories=Graphics;Development;
+Comment=Create maps for Pokemon DS games in a tilebased format
 " > PDSMS.desktop
 
 echo "Pokemon DS Map Studio has been installed! Enjoy ;)"


### PR DESCRIPTION
This adds a short description to the desktop menu entry installed by the PDSMS Linux script. It also adds the program to the "Graphics" menu category along with "Development", which I found more appropriate. Made because I was bugged by the program being the only one without a description in my menu lol